### PR TITLE
Update dna_calibration.mod

### DIFF
--- a/dna_calibration.mod
+++ b/dna_calibration.mod
@@ -21,3 +21,9 @@ PYTHONPATH +:=
 PYTHONPATH +:= data
 PYTHONPATH +:= lib/Maya2023/linux
 MAYA_PLUG_IN_PATH +:= lib/Maya2023/linux
+
++ MAYAVERSION:2024 PLATFORM:win64 MetaHuman-DNA-Calibration any .
+PYTHONPATH +:=
+PYTHONPATH +:= data
+PYTHONPATH +:= lib/Maya2024/windows
+MAYA_PLUG_IN_PATH +:= lib/Maya2024/windows


### PR DESCRIPTION
I have added the code to the mod file to make it work with Maya 2024.

```
+ MAYAVERSION:2024 PLATFORM:win64 MetaHuman-DNA-Calibration any .
PYTHONPATH +:=
PYTHONPATH +:= data
PYTHONPATH +:= lib/Maya2024/windows
MAYA_PLUG_IN_PATH +:= lib/Maya2024/windows
```

This will enable the plugin to work with Maya 2024 as it will show up in the plugins folder. Otherwise Maya will look in the Quixel bridge folder which does not work with Maya 2024