### PR TITLE
keep geometry_meshes order

### DIFF
--- a/dna_viewer/dnalib/geometry.py
+++ b/dna_viewer/dnalib/geometry.py
@@ -28,10 +28,10 @@ class Geometry(Definition):
 
         if not self.geometry_read and self.layer_enabled(Layer.geometry):
             self.geometry_read = True
-            self.geometry_meshes = []
-            for lod in range(self.get_lod_count()):
-                for mesh_index in self.get_mesh_indices_for_lod(lod):
-                    self.geometry_meshes.append(self.add_mesh(mesh_index))
+            self.geometry_meshes = [
+                self.add_mesh(mesh_index)
+                for mesh_index in range(self.get_mesh_count())
+            ]
 
     def get_maximum_influence_per_vertex(self, mesh_index: int) -> int:
         return cast(int, self.reader.getMaximumInfluencePerVertex(meshIndex=mesh_index))


### PR DESCRIPTION
Hello,

When adding additional meshes to a DNA the mesh indices are not sequential anymore.

This means the indices for example LOD0 might be [0, 1, 2, 99], in that example the Mesh object associated with mesh_index 99 gets appended to self.geometry_meshes at index 3 causing the mesh data to go out of sync.

I've done some quick testing and it seems to work, but I am only just starting working on DNA files so it could be I am missing something obvious.


