### PR TITLE
parent root joint

### DIFF
--- a/dna_viewer/builder/builder.py
+++ b/dna_viewer/builder/builder.py
@@ -148,7 +148,10 @@ class Builder:
             joints = self._add_joints()
 
             if self.config.group_by_lod and joints:
-                cmds.parent(joints[0].name, self.config.get_top_level_group())
+                for joint in joints:
+                    if joint.name == joint.parent_name:
+                        cmds.parent(joint.name, self.config.get_top_level_group())
+                        break
 
     def create_groups(self) -> None:
         """


### PR DESCRIPTION
Hello, 

During the joint build process the root joint is considered to be at index 0.
When adjusting the joint hierarchy this constraint can be inconvenient. 
The code is updated to loop the joints until the root joint is found.

